### PR TITLE
Bump Spring version we depend on.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.4.RELEASE</version>
+		<version>2.1.5.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.sst.nt.lms</groupId>


### PR DESCRIPTION
Version 2.1.4 pulls in versions of various dependencies that Snyk identifies
as having serious security vulnerabilities.