### PR TITLE
Upgrade Spring dependency to latest version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.5.RELEASE</version>
+		<version>2.1.6.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.sst.nt.lms</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.7.RELEASE</version>
+		<version>2.1.8.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.sst.nt.lms</groupId>
@@ -16,8 +16,8 @@
 
 	<properties>
 		<java.version>1.8</java.version>
-		<spring-cloud.version>Greenwich.SR2</spring-cloud.version>
-		<jackson.version>2.9.9.20190807</jackson.version>
+		<spring-cloud.version>Greenwich.SR3</spring-cloud.version>
+		<jackson.version>2.9.10</jackson.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.6.RELEASE</version>
+		<version>2.1.7.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.sst.nt.lms</groupId>
@@ -17,7 +17,7 @@
 	<properties>
 		<java.version>1.8</java.version>
 		<spring-cloud.version>Greenwich.SR2</spring-cloud.version>
-		<!-- <jackson.version>2.9.9.1</jackson.version --> <!-- Uncomment as soon as FasterXML/jackson-bom#22 merged -->
+		<jackson.version>2.9.9.20190807</jackson.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
 	<properties>
 		<java.version>1.8</java.version>
 		<spring-cloud.version>Greenwich.SR2</spring-cloud.version>
+		<!-- <jackson.version>2.9.9.1</jackson.version --> <!-- Uncomment as soon as FasterXML/jackson-bom#22 merged -->
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
 	<properties>
 		<java.version>1.8</java.version>
-		<spring-cloud.version>Greenwich.SR1</spring-cloud.version>
+		<spring-cloud.version>Greenwich.SR2</spring-cloud.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Prior version depends on versions of its dependencies with known vulnerabilities, though
it's not clear that the newer version fixes that. I'll try to figure out how to specify those updated dependency versions and update this PR.

I plan to merge this in my fork immediately, but better to have a PR "upstream" than leave it vulnerable and unnotified.